### PR TITLE
Support setUserEmail and setUserName

### DIFF
--- a/src/hockey-app.ts
+++ b/src/hockey-app.ts
@@ -190,4 +190,52 @@ export class HockeyApp {
       }
     });
   }
+
+  /**
+   * Set the user's e-mail address.
+   * @param userEmail      The user's e-mail address.
+   */
+  public setUserEmail(userEmail: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      if (this.window[<any>'hockeyapp']) {
+        this.window[<any>'hockeyapp'].setUserEmail((success: any) => {
+          resolve(success);
+        }, (err: any) => {
+          reject(err);
+        }, userEmail);
+      } else {
+        if (this.platform.is('core') || this.platform.is('mobileweb')) {
+          console.warn('HockeyApp unable to set the users e-mail address on this platform')
+          resolve();
+        } else {
+          reject('HockeyApp is not found, please make sure the cordova-hockeyapp-plugin is installed and on a supported platform');
+        }
+      }
+    });
+
+  }
+
+  /**
+   * Set the user's name.
+   * @param userName      The user's name.
+   */
+  public setUserName(userName: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      if (this.window[<any>'hockeyapp']) {
+        this.window[<any>'hockeyapp'].setUserName((success: any) => {
+          resolve(success);
+        }, (err: any) => {
+          reject(err);
+        }, userName);
+      } else {
+        if (this.platform.is('core') || this.platform.is('mobileweb')) {
+          console.warn('HockeyApp unable to set the users name on this platform')
+          resolve();
+        } else {
+          reject('HockeyApp is not found, please make sure the cordova-hockeyapp-plugin is installed and on a supported platform');
+        }
+      }
+    });
+
+  }
 }


### PR DESCRIPTION
Our app authenticates our users so we don't want to force the user to enter their details if they send feedback via HockeyApp.

This PR adds methods to allow setting the user's e-mail address and name as exposed by HockeyApp.

I hope this is of use, doesn't cause issues, and can be of use to others.